### PR TITLE
Add metadata appropriate for a WICG specification.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1,6 +1,6 @@
 <pre class="metadata">
 Title: HTML Sanitizer API
-Status: DREAM
+Status: CG-DRAFT
 Group: WICG
 URL: https://wicg.github.io/purification/
 Repository: WICG/purification

--- a/index.src.html
+++ b/index.src.html
@@ -1,7 +1,10 @@
 <pre class="metadata">
 Title: HTML Sanitizer API
 Status: DREAM
-Shortname: sanitizer
+Group: WICG
+URL: https://wicg.github.io/purification/
+Repository: WICG/purification
+Shortname: purification
 Level: 1
 Editor: Frederik Braun 68466, Mozilla, fbraun@mozilla.com, https://frederik-braun.com
 Editor: Mario Heiderich, Cure53, mario@cure53.de, https://cure53.de
@@ -11,7 +14,7 @@ Abstract:
   strings of HTML, and sanitize them for safe insertion into a document's DOM.
 Indent: 2
 Work Status: exploring
-Boilerplate: omit conformance, omit feedback-header
+Boilerplate: omit conformance
 Markup Shorthands: css off, markdown on
 </pre>
 <pre class="anchors">


### PR DESCRIPTION
This should reflect where the spec is being maintained.

I expect this additional metadata will allow working auto-import into
https://github.com/mozilla/standards-positions/

Note that this changes the license information that is generated.