### PR TITLE
upgrade python to unbreak travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: false
 language: python
-python:
-  - "2.7"
 install:
   - git clone https://github.com/tabatkins/bikeshed.git
   - pip install --editable $PWD/bikeshed

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: python
+python:
+  - "3.7"
 install:
   - git clone https://github.com/tabatkins/bikeshed.git
   - pip install --editable $PWD/bikeshed


### PR DESCRIPTION
travis fails with bikeshed requiring a python that isn't 2.7